### PR TITLE
Added follow to blacklist

### DIFF
--- a/lib/nano-blue.js
+++ b/lib/nano-blue.js
@@ -4,7 +4,7 @@ var bluebird = require('bluebird');
 var nano = require('nano');
 var _ = require('lodash');
 
-const blacklist = new Set(['use', 'scope']);
+const blacklist = new Set(['use', 'scope', 'follow']);
 
 /**
  * Promisifies the exposed functions on an object


### PR DESCRIPTION
The callback accepted by follow is not a normal callback; it receives changes when they occur, so in most cases, the promise will just hang there. The above change excludes follow from promisification.
